### PR TITLE
Add native-image hints, tests, and query fallback

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,3 @@
+config.stopBubbling = true
+# Add @lombok.Generated to all generated methods so JaCoCo excludes them from coverage.
+lombok.addLombokGeneratedAnnotation = true

--- a/native-test.bat
+++ b/native-test.bat
@@ -1,0 +1,54 @@
+@echo off
+setlocal
+REM Local GraalVM nativeTest runner for spring-web-captor. Pass the module via -pl, e.g.:
+REM   native-test.bat -pl spring-web-captor
+REM   native-test.bat -pl spring-web-captor-xml
+REM   native-test.bat -pl spring-web-captor-storage
+REM Run modules ONE AT A TIME (each native-image build uses ~6-9GB RAM).
+REM
+REM No machine-specific paths are hardcoded. Requirements:
+REM   - GRAALVM_HOME : a GraalVM 21 JDK (must contain bin\native-image). If unset, JAVA_HOME is used
+REM                    only when it is itself a GraalVM.
+REM   - Visual Studio / Build Tools with the C++ workload (located automatically via vswhere).
+REM   - Optional NATIVE_M2 : local Maven repo for native builds (defaults to a path without spaces,
+REM                          since spaces in the repo path break native-image).
+
+cd /d "%~dp0"
+
+REM --- Resolve GraalVM (prefer GRAALVM_HOME; else JAVA_HOME if it has native-image) ---
+set "GVM=%GRAALVM_HOME%"
+if not defined GVM if exist "%JAVA_HOME%\bin\native-image.cmd" set "GVM=%JAVA_HOME%"
+if not defined GVM (
+  echo ERROR: Set GRAALVM_HOME to a GraalVM 21 JDK ^(must contain bin\native-image^).
+  exit /b 1
+)
+if not exist "%GVM%\bin\native-image.cmd" (
+  echo ERROR: "%GVM%" is not a GraalVM with native-image ^(bin\native-image.cmd missing^).
+  exit /b 1
+)
+set "JAVA_HOME=%GVM%"
+set "PATH=%JAVA_HOME%\bin;%PATH%"
+
+REM --- Load MSVC x64 build env (native-image needs cl.exe). Locate VS via vswhere (any edition/year). ---
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" (
+  echo ERROR: vswhere not found. Install Visual Studio / Build Tools with the C++ workload.
+  exit /b 1
+)
+set "VSINSTALL="
+for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
+if not defined VSINSTALL (
+  echo ERROR: No Visual Studio with the C++ ^(VC.Tools.x86.x64^) component was found.
+  exit /b 1
+)
+call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat" >nul
+
+REM --- Native-friendly local repo (spaces in the path break native-image). Override via NATIVE_M2. ---
+if not defined NATIVE_M2 set "NATIVE_M2=%HOMEDRIVE%\mvnrepo"
+
+REM -Dgroups=native: native-compile + run only the @Tag("native") boot subset.
+REM -Djacoco.check.phase=none: the single-context native run scopes coverage low; the JVM build owns the 80% gate.
+call "%~dp0mvnw.cmd" ^
+  -ntp -PnativeTest -Dgroups=native -Djacoco.check.phase=none ^
+  -Dmaven.repo.local="%NATIVE_M2%" ^
+  %* clean test

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,15 @@
         <module>spring-web-captor-storage</module>
     </modules>
     <properties>
-        <revision>1.1.2</revision>
+        <revision>1.2.0</revision>
 
         <java.version>21</java.version>
+
+        <!-- JaCoCo line-coverage gate, scoped to the library's own packages (a @SpringBootTest
+             otherwise instruments all of Spring and dilutes the report). Lever: the native build
+             passes -Djacoco.check.phase=none because the single-context native run scopes coverage low. -->
+        <jacoco.check.phase>verify</jacoco.check.phase>
+        <jacoco.line.coverage>0.80</jacoco.line.coverage>
     </properties>
     <dependencies>
         <dependency>
@@ -53,16 +59,101 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <scope>provided</scope>
+            <!-- compile+optional (not provided): the library references autoconfigure types directly
+                 (e.g. ErrorProperties) and provided-scope deps are excluded from the native-image runtime
+                 classpath. Optional keeps it non-transitive for consumers, who already bring spring-boot. -->
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- Required for process-test-aot / native JUnit test discovery under the nativeTest profile. -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
+            <!-- Library jars have no application main class — skip repackage (needed so the
+                 spring-boot-maven-plugin's process-test-aot goal runs under the nativeTest profile). -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>repackage</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Windows native-image builder needs more heap than its ~32% RAM default, or ParallelGC
+                 segfaults mid-analysis. TestTag must init at build time for bare @Tag to work. -->
+            <plugin>
+                <groupId>org.graalvm.buildtools</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <configuration>
+                    <buildArgs>
+                        <buildArg>-J-Xmx10g</buildArg>
+                        <buildArg>--initialize-at-build-time=org.junit.platform.engine.TestTag</buildArg>
+                    </buildArgs>
+                </configuration>
+            </plugin>
+            <!-- Line-coverage gate, scoped to com/davidrandoll/** so a @SpringBootTest doesn't dilute it. -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <configuration>
+                    <includes>
+                        <include>com/davidrandoll/**</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/aot/**</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <phase>${jacoco.check.phase}</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${jacoco.line.coverage}</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>

--- a/spring-web-captor-storage/pom.xml
+++ b/spring-web-captor-storage/pom.xml
@@ -30,15 +30,17 @@
             <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
+        <!-- compile+optional (not provided): kept non-transitive for consumers but present on this
+             module's native-image test classpath (provided is excluded from the native runtime classpath). -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-web-captor-storage/src/main/java/com/davidrandoll/spring_web_captor/storage/aot/NetworkLogStorageRuntimeHints.java
+++ b/spring-web-captor-storage/src/main/java/com/davidrandoll/spring_web_captor/storage/aot/NetworkLogStorageRuntimeHints.java
@@ -1,0 +1,28 @@
+package com.davidrandoll.spring_web_captor.storage.aot;
+
+import com.davidrandoll.spring_web_captor.storage.NetworkLogProperties;
+import org.springframework.aot.hint.BindingReflectionHintsRegistrar;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.lang.Nullable;
+
+/**
+ * Native-image reflection metadata for the storage module's own configuration-binding type graph.
+ *
+ * <p>The persisted {@code INetworkLog} implementation is supplied by the consumer (typically a JPA entity or
+ * document) and is registered by the consumer's own AOT processing — the library cannot know that type. What
+ * the library owns and must guarantee binds under native is {@link NetworkLogProperties} and its nested
+ * {@code CaptureRule}; this is normally handled by Spring Boot's {@code @ConfigurationProperties} AOT support,
+ * registered here as well so binding holds even outside standard auto-configuration.</p>
+ */
+public class NetworkLogStorageRuntimeHints implements RuntimeHintsRegistrar {
+
+    private final BindingReflectionHintsRegistrar bindingRegistrar = new BindingReflectionHintsRegistrar();
+
+    @Override
+    public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+        bindingRegistrar.registerReflectionHints(hints.reflection(),
+                NetworkLogProperties.class,
+                NetworkLogProperties.CaptureRule.class);
+    }
+}

--- a/spring-web-captor-storage/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-web-captor-storage/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=\
+com.davidrandoll.spring_web_captor.storage.aot.NetworkLogStorageRuntimeHints

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/CaptureRuleResolverTest.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/CaptureRuleResolverTest.java
@@ -1,0 +1,89 @@
+package com.davidrandoll.spring_web_captor.storage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CaptureRuleResolverTest {
+
+    @Test
+    void skipWhenPropertiesNull() {
+        var decision = CaptureRuleResolver.resolve(200, null);
+        assertThat(decision.capture()).isFalse();
+    }
+
+    @Test
+    void skipWhenDisabled() {
+        NetworkLogProperties props = new NetworkLogProperties();
+        props.setEnabled(false);
+        assertThat(CaptureRuleResolver.resolve(200, props).capture()).isFalse();
+    }
+
+    @Test
+    void captureAllWhenNoRulesAndNoStatusFilter() {
+        NetworkLogProperties props = new NetworkLogProperties();
+        var decision = CaptureRuleResolver.resolve(200, props);
+        assertThat(decision.capture()).isTrue();
+        assertThat(decision.fieldWhitelist()).isNull();
+    }
+
+    @Test
+    void legacyCaptureStatusesFilter() {
+        NetworkLogProperties props = new NetworkLogProperties();
+        props.setCaptureStatuses(List.of(">=400"));
+        assertThat(CaptureRuleResolver.resolve(500, props).capture()).isTrue();
+        assertThat(CaptureRuleResolver.resolve(200, props).capture()).isFalse();
+    }
+
+    @Test
+    void rulesMatchWithFullFieldCapture() {
+        NetworkLogProperties props = new NetworkLogProperties();
+        NetworkLogProperties.CaptureRule rule = new NetworkLogProperties.CaptureRule();
+        rule.setMatch(List.of(">=500"));
+        props.setRules(List.of(rule));
+
+        var decision = CaptureRuleResolver.resolve(503, props);
+        assertThat(decision.capture()).isTrue();
+        assertThat(decision.fieldWhitelist()).isNull(); // null/empty fields => capture all
+    }
+
+    @Test
+    void rulesMatchWithFieldWhitelist() {
+        NetworkLogProperties props = new NetworkLogProperties();
+        NetworkLogProperties.CaptureRule rule = new NetworkLogProperties.CaptureRule();
+        rule.setMatch(List.of("400-599"));
+        rule.setFields(List.of("path", "responseStatus"));
+        props.setRules(List.of(rule));
+
+        var decision = CaptureRuleResolver.resolve(404, props);
+        assertThat(decision.capture()).isTrue();
+        assertThat(decision.fieldWhitelist()).containsExactlyInAnyOrder("path", "responseStatus");
+    }
+
+    @Test
+    void noMatchingRuleSkips() {
+        NetworkLogProperties props = new NetworkLogProperties();
+        NetworkLogProperties.CaptureRule rule = new NetworkLogProperties.CaptureRule();
+        rule.setMatch(List.of(">=500"));
+        props.setRules(List.of(rule));
+
+        assertThat(CaptureRuleResolver.resolve(200, props).capture()).isFalse();
+    }
+
+    @Test
+    void firstMatchingRuleWins() {
+        NetworkLogProperties props = new NetworkLogProperties();
+        NetworkLogProperties.CaptureRule first = new NetworkLogProperties.CaptureRule();
+        first.setMatch(List.of(">=500"));
+        first.setFields(List.of("path"));
+        NetworkLogProperties.CaptureRule second = new NetworkLogProperties.CaptureRule();
+        second.setMatch(List.of(">=400"));
+        second.setFields(List.of("responseBody"));
+        props.setRules(List.of(first, second));
+
+        var decision = CaptureRuleResolver.resolve(503, props);
+        assertThat(decision.fieldWhitelist()).containsExactly("path");
+    }
+}

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/NetworkLogEventListenerTest.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/NetworkLogEventListenerTest.java
@@ -1,0 +1,299 @@
+package com.davidrandoll.spring_web_captor.storage;
+
+import com.davidrandoll.spring_web_captor.event.HttpMethodEnum;
+import com.davidrandoll.spring_web_captor.event.HttpRequestEvent;
+import com.davidrandoll.spring_web_captor.event.HttpResponseEvent;
+import com.davidrandoll.spring_web_captor.storage.support.InMemoryNetworkLogStore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.davidrandoll.spring_web_captor.storage.NetworkLogHttpEventExtension.REQUEST_ID_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NetworkLogEventListenerTest {
+
+    private static final String RID = "req-123";
+
+    private InMemoryNetworkLogStore store;
+    private NetworkLogProperties properties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private List<NetworkLogEnricher> enrichers;
+    private NetworkLogEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryNetworkLogStore();
+        properties = new NetworkLogProperties();
+        enrichers = new ArrayList<>();
+        listener = new NetworkLogEventListener(store, properties, objectMapper, enrichers);
+    }
+
+    private HttpRequestEvent.HttpRequestEventBuilder<?, ?> requestBuilder() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer secret");
+        headers.add("X-Custom", "keep-me");
+
+        MultiValueMap<String, String> query = new LinkedMultiValueMap<>();
+        query.add("color", "blue");
+
+        Map<String, String> pathParams = new HashMap<>();
+        pathParams.put("id", "42");
+
+        return HttpRequestEvent.builder()
+                .method(HttpMethodEnum.GET)
+                .fullUrl("http://localhost/api/things/42?color=blue")
+                .path("/api/things/42")
+                .headers(headers)
+                .queryParams(query)
+                .pathParams(pathParams)
+                .endpointCalled(true)
+                .additionalData(REQUEST_ID_KEY, RID);
+    }
+
+    @Test
+    void requestPhasePersistsRowWithDefaultAuthorizationRedaction() {
+        listener.onHttpRequest(requestBuilder().build());
+
+        INetworkLog saved = store.findByRequestId(RID).orElseThrow();
+        assertThat(saved.getMethod()).isEqualTo("GET");
+        assertThat(saved.getPath()).isEqualTo("/api/things/42");
+        assertThat(saved.getFullUrl()).contains("color=blue");
+        assertThat(saved.getRequestHeaders().get("Authorization")).isEqualTo("[REDACTED]");
+        assertThat(saved.getRequestHeaders().get("X-Custom")).isEqualTo("keep-me");
+        assertThat(saved.getQueryParams()).containsEntry("color", "blue");
+        assertThat(saved.getPathParams()).containsEntry("id", "42");
+        assertThat(saved.getEndpointCalled()).isTrue();
+        assertThat(saved.getRequestTimestamp()).isNotNull();
+    }
+
+    @Test
+    void requestPhaseSkippedWhenDisabled() {
+        properties.setEnabled(false);
+        listener.onHttpRequest(requestBuilder().build());
+        assertThat(store.size()).isZero();
+    }
+
+    @Test
+    void requestPhaseSkippedForExcludedPath() {
+        properties.setExcludePaths(List.of("/api/things"));
+        listener.onHttpRequest(requestBuilder().build());
+        assertThat(store.size()).isZero();
+    }
+
+    @Test
+    void requestPhaseToleratesStoreFailure() {
+        NetworkLogEventListener boom = new NetworkLogEventListener(new InMemoryNetworkLogStore() {
+            @Override
+            public void save(INetworkLog log) {
+                throw new IllegalStateException("db down");
+            }
+        }, properties, objectMapper, enrichers);
+        // should swallow the exception rather than propagate
+        boom.onHttpRequest(requestBuilder().build());
+    }
+
+    @Test
+    void responsePhaseUpdatesExistingRow() {
+        listener.onHttpRequest(requestBuilder().build());
+
+        HttpResponseEvent response = HttpResponseEvent.builder()
+                .method(HttpMethodEnum.GET)
+                .path("/api/things/42")
+                .responseStatus(HttpStatus.OK)
+                .responseHeaders(new HttpHeaders())
+                .additionalData(REQUEST_ID_KEY, RID)
+                .build();
+        response.setResponseBody(JsonNodeFactory.instance.textNode("ok"));
+
+        listener.onHttpResponse(response);
+
+        INetworkLog saved = store.findByRequestId(RID).orElseThrow();
+        assertThat(saved.getResponseStatus()).isEqualTo(200);
+        assertThat(saved.getResponseBody().asText()).isEqualTo("ok");
+    }
+
+    @Test
+    void responsePhaseCreatesRowWhenNoRequestRowExists() {
+        HttpResponseEvent response = HttpResponseEvent.builder()
+                .method(HttpMethodEnum.POST)
+                .path("/api/orphan")
+                .fullUrl("http://localhost/api/orphan")
+                .headers(new HttpHeaders())
+                .responseStatus(HttpStatus.CREATED)
+                .responseHeaders(new HttpHeaders())
+                .endpointCalled(true)
+                .additionalData(REQUEST_ID_KEY, RID)
+                .build();
+
+        listener.onHttpResponse(response);
+
+        INetworkLog saved = store.findByRequestId(RID).orElseThrow();
+        assertThat(saved.getMethod()).isEqualTo("POST");
+        assertThat(saved.getResponseStatus()).isEqualTo(201);
+    }
+
+    @Test
+    void responsePhaseDeletesRowWhenCaptureRuleRejects() {
+        // Only capture >=500; a 200 response should drop the previously stored request row.
+        properties.setCaptureStatuses(List.of(">=500"));
+        listener.onHttpRequest(requestBuilder().build());
+        assertThat(store.size()).isEqualTo(1);
+
+        HttpResponseEvent response = HttpResponseEvent.builder()
+                .path("/api/things/42")
+                .responseStatus(HttpStatus.OK)
+                .additionalData(REQUEST_ID_KEY, RID)
+                .build();
+        listener.onHttpResponse(response);
+
+        assertThat(store.findByRequestId(RID)).isEmpty();
+    }
+
+    @Test
+    void responsePhaseAppliesFieldWhitelistMask() {
+        NetworkLogProperties.CaptureRule rule = new NetworkLogProperties.CaptureRule();
+        rule.setMatch(List.of(">=400"));
+        rule.setFields(List.of("path"));
+        properties.setRules(List.of(rule));
+
+        listener.onHttpRequest(requestBuilder().build());
+
+        HttpResponseEvent response = HttpResponseEvent.builder()
+                .method(HttpMethodEnum.GET)
+                .path("/api/things/42")
+                .responseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+                .responseHeaders(new HttpHeaders())
+                .additionalData(REQUEST_ID_KEY, RID)
+                .build();
+        listener.onHttpResponse(response);
+
+        INetworkLog saved = store.findByRequestId(RID).orElseThrow();
+        assertThat(saved.getPath()).isEqualTo("/api/things/42"); // whitelisted
+        assertThat(saved.getMethod()).isNull();                  // masked
+        assertThat(saved.getResponseStatus()).isEqualTo(500);    // always kept
+    }
+
+    @Test
+    void responsePhaseSkippedForExcludedPath() {
+        properties.setExcludePaths(List.of("/api"));
+        HttpResponseEvent response = HttpResponseEvent.builder()
+                .path("/api/x")
+                .responseStatus(HttpStatus.OK)
+                .additionalData(REQUEST_ID_KEY, RID)
+                .build();
+        listener.onHttpResponse(response);
+        assertThat(store.size()).isZero();
+    }
+
+    @Test
+    void enrichersAreInvokedAndFailuresTolerated() {
+        List<String> calls = new ArrayList<>();
+        enrichers.add((log, event) -> {
+            calls.add("ok");
+            log.setAdditionalData(merge(log.getAdditionalData(), "tenant", "acme"));
+        });
+        enrichers.add((log, event) -> {
+            throw new RuntimeException("enricher boom");
+        });
+
+        listener.onHttpRequest(requestBuilder().build());
+
+        assertThat(calls).containsExactly("ok");
+        INetworkLog saved = store.findByRequestId(RID).orElseThrow();
+        assertThat(saved.getAdditionalData()).containsEntry("tenant", "acme");
+    }
+
+    @Test
+    void redactsConfiguredHeadersCaseInsensitively() {
+        properties.setRedactHeaders(List.of("x-custom"));
+        listener.onHttpRequest(requestBuilder().build());
+
+        INetworkLog saved = store.findByRequestId(RID).orElseThrow();
+        assertThat(saved.getRequestHeaders().get("X-Custom")).isEqualTo("[REDACTED]");
+        // Authorization no longer redacted because we overrode the redact list
+        assertThat(saved.getRequestHeaders().get("Authorization")).isEqualTo("Bearer secret");
+    }
+
+    @Test
+    void redactsConfiguredBodyAndAdditionalDataFieldsRecursively() {
+        properties.setRedactFields(List.of("password"));
+
+        ObjectNode body = JsonNodeFactory.instance.objectNode();
+        body.put("username", "david");
+        body.put("password", "p@ss");
+        ObjectNode nested = body.putObject("nested");
+        nested.put("password", "deep");
+
+        Map<String, Object> extra = new HashMap<>();
+        extra.put(REQUEST_ID_KEY, RID);
+        extra.put("password", "in-additional-data");
+
+        HttpRequestEvent event = HttpRequestEvent.builder()
+                .method(HttpMethodEnum.POST)
+                .path("/api/login")
+                .headers(new HttpHeaders())
+                .additionalData(extra)
+                .build();
+        event.setBodyPayload(new com.davidrandoll.spring_web_captor.event.BodyPayload(body));
+
+        listener.onHttpRequest(event);
+
+        INetworkLog saved = store.findByRequestId(RID).orElseThrow();
+        assertThat(saved.getRequestBody().get("password").asText()).isEqualTo("[REDACTED]");
+        assertThat(saved.getRequestBody().get("username").asText()).isEqualTo("david");
+        assertThat(saved.getRequestBody().get("nested").get("password").asText()).isEqualTo("[REDACTED]");
+        assertThat(saved.getAdditionalData().get("password")).isEqualTo("[REDACTED]");
+    }
+
+    @Test
+    void responsePhaseMergesAdditionalDataAcrossPhases() {
+        Map<String, Object> reqExtra = new HashMap<>();
+        reqExtra.put(REQUEST_ID_KEY, RID);
+        reqExtra.put("phase", "request");
+        listener.onHttpRequest(requestBuilder().additionalData(reqExtra).build());
+
+        Map<String, Object> resExtra = new HashMap<>();
+        resExtra.put(REQUEST_ID_KEY, RID);
+        resExtra.put("extra", "response");
+        HttpResponseEvent response = HttpResponseEvent.builder()
+                .path("/api/things/42")
+                .responseStatus(HttpStatus.OK)
+                .responseHeaders(new HttpHeaders())
+                .additionalData(resExtra)
+                .build();
+        listener.onHttpResponse(response);
+
+        INetworkLog saved = store.findByRequestId(RID).orElseThrow();
+        assertThat(saved.getAdditionalData()).containsEntry("phase", "request");
+        assertThat(saved.getAdditionalData()).containsEntry("extra", "response");
+    }
+
+    @Test
+    void responseWithoutRequestIdIsToleratedOnReject() {
+        properties.setCaptureStatuses(List.of(">=500"));
+        HttpResponseEvent response = HttpResponseEvent.builder()
+                .path("/api/x")
+                .responseStatus(HttpStatus.OK)
+                .build(); // no requestId in additionalData
+        listener.onHttpResponse(response);
+        assertThat(store.size()).isZero();
+    }
+
+    private static Map<String, Object> merge(Map<String, Object> existing, String k, Object v) {
+        Map<String, Object> m = existing == null ? new HashMap<>() : new HashMap<>(existing);
+        m.put(k, v);
+        return m;
+    }
+}

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/NetworkLogFieldMaskTest.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/NetworkLogFieldMaskTest.java
@@ -1,0 +1,79 @@
+package com.davidrandoll.spring_web_captor.storage;
+
+import com.davidrandoll.spring_web_captor.storage.support.TestNetworkLog;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NetworkLogFieldMaskTest {
+
+    private TestNetworkLog fullyPopulated() {
+        TestNetworkLog log = new TestNetworkLog();
+        log.setRequestId("rid")
+                .setRequestTimestamp(Instant.now())
+                .setMethod("GET")
+                .setFullUrl("http://x/y")
+                .setPath("/y")
+                .setEndpointCalled(true)
+                .setRequestHeaders(Map.of("h", "v"))
+                .setQueryParams(Map.of("q", "1"))
+                .setPathParams(Map.of("p", "2"))
+                .setRequestBody(new TextNode("req"))
+                .setAdditionalData(Map.of("a", "b"))
+                .setResponseStatus(200)
+                .setResponseHeaders(Map.of("rh", "rv"))
+                .setResponseBody(new TextNode("res"))
+                .setErrorDetail(Map.of("e", "d"));
+        return log;
+    }
+
+    @Test
+    void nullWhitelistIsNoOp() {
+        TestNetworkLog log = fullyPopulated();
+        NetworkLogFieldMask.apply(log, null);
+        assertThat(log.getPath()).isEqualTo("/y");
+        assertThat(log.getResponseBody()).isNotNull();
+    }
+
+    @Test
+    void emptyWhitelistIsNoOp() {
+        TestNetworkLog log = fullyPopulated();
+        NetworkLogFieldMask.apply(log, Set.of());
+        assertThat(log.getMethod()).isEqualTo("GET");
+    }
+
+    @Test
+    void nullLogIsTolerated() {
+        NetworkLogFieldMask.apply(null, Set.of("path"));
+    }
+
+    @Test
+    void onlyWhitelistedAndAlwaysKeptFieldsSurvive() {
+        TestNetworkLog log = fullyPopulated();
+        NetworkLogFieldMask.apply(log, Set.of("path", "responseBody"));
+
+        // whitelisted
+        assertThat(log.getPath()).isEqualTo("/y");
+        assertThat(log.getResponseBody()).isNotNull();
+        // always kept regardless of whitelist
+        assertThat(log.getRequestId()).isEqualTo("rid");
+        assertThat(log.getRequestTimestamp()).isNotNull();
+        assertThat(log.getResponseStatus()).isEqualTo(200);
+        // masked away
+        assertThat(log.getMethod()).isNull();
+        assertThat(log.getFullUrl()).isNull();
+        assertThat(log.getEndpointCalled()).isNull();
+        assertThat(log.getRequestHeaders()).isNull();
+        assertThat(log.getQueryParams()).isNull();
+        assertThat(log.getPathParams()).isNull();
+        assertThat(log.getRequestBody()).isNull();
+        assertThat(log.getAdditionalData()).isNull();
+        assertThat(log.getResponseHeaders()).isNull();
+        assertThat(log.getErrorDetail()).isNull();
+    }
+}

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/NetworkLogHttpEventExtensionTest.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/NetworkLogHttpEventExtensionTest.java
@@ -1,0 +1,73 @@
+package com.davidrandoll.spring_web_captor.storage;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Map;
+
+import static com.davidrandoll.spring_web_captor.storage.NetworkLogHttpEventExtension.REQUEST_ID_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NetworkLogHttpEventExtensionTest {
+
+    private final NetworkLogHttpEventExtension extension =
+            new NetworkLogHttpEventExtension(RequestIdProvider.uuid());
+
+    @Test
+    void requestEnrichmentGeneratesAndStashesRequestId() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        Map<String, Object> data = extension.enrichRequestEvent(req, res, null);
+
+        Object id = data.get(REQUEST_ID_KEY);
+        assertThat(id).isInstanceOf(String.class);
+        assertThat((String) id).isNotBlank();
+        // id is stashed on the request so a later dispatch reuses it
+        assertThat(req.getAttribute(REQUEST_ID_KEY)).isEqualTo(id);
+    }
+
+    @Test
+    void requestEnrichmentReusesExistingRequestId() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setAttribute(REQUEST_ID_KEY, "existing-id");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        Map<String, Object> data = extension.enrichRequestEvent(req, res, null);
+
+        assertThat(data.get(REQUEST_ID_KEY)).isEqualTo("existing-id");
+    }
+
+    @Test
+    void requestEnrichmentIgnoresBlankExistingRequestId() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setAttribute(REQUEST_ID_KEY, "");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        Map<String, Object> data = extension.enrichRequestEvent(req, res, null);
+
+        assertThat((String) data.get(REQUEST_ID_KEY)).isNotBlank();
+    }
+
+    @Test
+    void responseEnrichmentCarriesRequestIdForward() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setAttribute(REQUEST_ID_KEY, "carry-id");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        Map<String, Object> data = extension.enrichResponseEvent(req, res, null, null);
+
+        assertThat(data.get(REQUEST_ID_KEY)).isEqualTo("carry-id");
+    }
+
+    @Test
+    void responseEnrichmentWithoutRequestIdReturnsEmptyData() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        Map<String, Object> data = extension.enrichResponseEvent(req, res, null, null);
+
+        assertThat(data).doesNotContainKey(REQUEST_ID_KEY);
+    }
+}

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/RequestIdProviderTest.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/RequestIdProviderTest.java
@@ -1,0 +1,24 @@
+package com.davidrandoll.spring_web_captor.storage;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class RequestIdProviderTest {
+
+    @Test
+    void uuidProviderReturnsDistinctParsableUuids() {
+        RequestIdProvider provider = RequestIdProvider.uuid();
+        MockHttpServletRequest req = new MockHttpServletRequest();
+
+        String a = provider.nextRequestId(req);
+        String b = provider.nextRequestId(req);
+
+        assertThat(a).isNotEqualTo(b);
+        assertThatNoException().isThrownBy(() -> UUID.fromString(a));
+    }
+}

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/StatusCaptureRuleTest.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/StatusCaptureRuleTest.java
@@ -1,0 +1,71 @@
+package com.davidrandoll.spring_web_captor.storage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StatusCaptureRuleTest {
+
+    @Test
+    void nullOrEmptyRulesCaptureEverything() {
+        assertThat(StatusCaptureRule.shouldCapture(200, null)).isTrue();
+        assertThat(StatusCaptureRule.shouldCapture(200, List.of())).isTrue();
+    }
+
+    @Test
+    void nullStatusIsCaptured() {
+        assertThat(StatusCaptureRule.shouldCapture(null, List.of("500"))).isTrue();
+    }
+
+    @Test
+    void exactMatch() {
+        assertThat(StatusCaptureRule.shouldCapture(404, List.of("404"))).isTrue();
+        assertThat(StatusCaptureRule.shouldCapture(200, List.of("404"))).isFalse();
+    }
+
+    @Test
+    void greaterThanOrEqual() {
+        assertThat(StatusCaptureRule.shouldCapture(500, List.of(">=400"))).isTrue();
+        assertThat(StatusCaptureRule.shouldCapture(399, List.of(">=400"))).isFalse();
+    }
+
+    @Test
+    void lessThanOrEqual() {
+        assertThat(StatusCaptureRule.shouldCapture(200, List.of("<=299"))).isTrue();
+        assertThat(StatusCaptureRule.shouldCapture(300, List.of("<=299"))).isFalse();
+    }
+
+    @Test
+    void strictlyGreaterThan() {
+        assertThat(StatusCaptureRule.shouldCapture(500, List.of(">499"))).isTrue();
+        assertThat(StatusCaptureRule.shouldCapture(499, List.of(">499"))).isFalse();
+    }
+
+    @Test
+    void strictlyLessThan() {
+        assertThat(StatusCaptureRule.shouldCapture(100, List.of("<200"))).isTrue();
+        assertThat(StatusCaptureRule.shouldCapture(200, List.of("<200"))).isFalse();
+    }
+
+    @Test
+    void inclusiveRange() {
+        assertThat(StatusCaptureRule.shouldCapture(450, List.of("400-599"))).isTrue();
+        assertThat(StatusCaptureRule.shouldCapture(400, List.of("400-599"))).isTrue();
+        assertThat(StatusCaptureRule.shouldCapture(599, List.of("400-599"))).isTrue();
+        assertThat(StatusCaptureRule.shouldCapture(399, List.of("400-599"))).isFalse();
+        assertThat(StatusCaptureRule.shouldCapture(600, List.of("400-599"))).isFalse();
+    }
+
+    @Test
+    void firstMatchingRuleWins() {
+        assertThat(StatusCaptureRule.shouldCapture(503, List.of("200", ">=500"))).isTrue();
+    }
+
+    @Test
+    void whitespaceInRuleIsTrimmed() {
+        assertThat(StatusCaptureRule.shouldCapture(500, List.of("  >= 400 "))).isTrue();
+        assertThat(StatusCaptureRule.shouldCapture(450, List.of(" 400 - 599 "))).isTrue();
+    }
+}

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/aot/NetworkLogStorageRuntimeHintsTest.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/aot/NetworkLogStorageRuntimeHintsTest.java
@@ -1,0 +1,25 @@
+package com.davidrandoll.spring_web_captor.storage.aot;
+
+import com.davidrandoll.spring_web_captor.storage.NetworkLogProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NetworkLogStorageRuntimeHintsTest {
+
+    private final RuntimeHints hints = new RuntimeHints();
+
+    NetworkLogStorageRuntimeHintsTest() {
+        new NetworkLogStorageRuntimeHints().registerHints(hints, getClass().getClassLoader());
+    }
+
+    @Test
+    @DisplayName("registers binding hints for NetworkLogProperties and its nested CaptureRule")
+    void registersConfigurationProperties() {
+        assertThat(RuntimeHintsPredicates.reflection().onType(NetworkLogProperties.class)).accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(NetworkLogProperties.CaptureRule.class)).accepts(hints);
+    }
+}

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/nativesupport/NetworkLogStorageNativeTest.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/nativesupport/NetworkLogStorageNativeTest.java
@@ -1,0 +1,91 @@
+package com.davidrandoll.spring_web_captor.storage.nativesupport;
+
+import com.davidrandoll.spring_web_captor.storage.INetworkLog;
+import com.davidrandoll.spring_web_captor.storage.NetworkLogEventListener;
+import com.davidrandoll.spring_web_captor.storage.support.InMemoryNetworkLogStore;
+import com.davidrandoll.spring_web_captor.storage.testapp.NetworkLogStorageTestApp;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Boots the storage auto-configuration ENABLED over a real captor + MockMvc and drives a real HTTP request so
+ * the whole capture -> event -> async storage-listener -> store path executes. This is the native-capable boot
+ * test (no Mockito, real objects only): it exercises the autoconfig bean wiring, the requestId extension, the
+ * NetworkLogProperties binding, and the listener's request/response persistence — exactly the paths that would
+ * break under a closed-world native image if a reflection/binding hint were missing.
+ */
+@SpringBootTest(classes = NetworkLogStorageTestApp.class, properties = {
+        "spring.application.name=network-log-storage-native-test",
+        "network-log.enabled=true",
+        "network-log.redact-headers=Authorization"
+})
+@AutoConfigureMockMvc
+@Tag("native")
+class NetworkLogStorageNativeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private InMemoryNetworkLogStore store;
+
+    @Autowired
+    private NetworkLogEventListener listener; // proves the @ConditionalOnBean listener wired
+
+    @BeforeEach
+    void reset() {
+        store.clear();
+    }
+
+    @Test
+    void contextWiresStorageBeans() {
+        assertThat(listener).isNotNull();
+        assertThat(store).isNotNull();
+    }
+
+    @Test
+    void realRequestIsCapturedEnrichedAndPersisted() throws Exception {
+        mockMvc.perform(get("/api/widgets/42?color=blue"))
+                .andExpect(status().isOk());
+
+        INetworkLog saved = awaitOneRow();
+
+        assertThat(saved.getMethod()).isEqualTo("GET");
+        assertThat(saved.getPath()).isEqualTo("/api/widgets/42");
+        assertThat(saved.getResponseStatus()).isEqualTo(200);
+        assertThat(saved.getRequestId()).isNotBlank();
+        // enricher ran
+        assertThat(saved.getAdditionalData()).containsEntry("enrichedTenant", "acme");
+    }
+
+    private INetworkLog awaitOneRow() {
+        Instant deadline = Instant.now().plus(Duration.ofSeconds(5));
+        while (Instant.now().isBefore(deadline)) {
+            Optional<INetworkLog> row = store.findAny();
+            // wait until the response phase has stamped the status, not just the request phase
+            if (row.isPresent() && row.get().getResponseStatus() != null) {
+                return row.get();
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        return store.findAny().orElseThrow(() -> new AssertionError("no network-log row was persisted"));
+    }
+}

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/support/InMemoryNetworkLogStore.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/support/InMemoryNetworkLogStore.java
@@ -1,0 +1,52 @@
+package com.davidrandoll.spring_web_captor.storage.support;
+
+import com.davidrandoll.spring_web_captor.storage.INetworkLog;
+import com.davidrandoll.spring_web_captor.storage.INetworkLogStore;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Hand-written native-safe fake of {@link INetworkLogStore} (no Mockito). Keeps saved logs in a concurrent map
+ * keyed by requestId so both the synchronous unit tests and the async integration/native boot test can read
+ * them back.
+ */
+public class InMemoryNetworkLogStore implements INetworkLogStore {
+
+    private final Map<String, INetworkLog> byRequestId = new ConcurrentHashMap<>();
+
+    @Override
+    public INetworkLog newInstance() {
+        return new TestNetworkLog();
+    }
+
+    @Override
+    public void save(INetworkLog log) {
+        if (log.getRequestId() != null) {
+            byRequestId.put(log.getRequestId(), log);
+        }
+    }
+
+    @Override
+    public Optional<INetworkLog> findByRequestId(String requestId) {
+        return Optional.ofNullable(byRequestId.get(requestId));
+    }
+
+    @Override
+    public void deleteByRequestId(String requestId) {
+        byRequestId.remove(requestId);
+    }
+
+    public int size() {
+        return byRequestId.size();
+    }
+
+    public void clear() {
+        byRequestId.clear();
+    }
+
+    public Optional<INetworkLog> findAny() {
+        return byRequestId.values().stream().findFirst();
+    }
+}

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/support/TestNetworkLog.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/support/TestNetworkLog.java
@@ -1,0 +1,34 @@
+package com.davidrandoll.spring_web_captor.storage.support;
+
+import com.davidrandoll.spring_web_captor.storage.INetworkLog;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Plain in-memory {@link INetworkLog} implementation used by the storage tests. {@code @Accessors(chain = true)}
+ * gives covariant chained setters that satisfy the {@code INetworkLog setX(...): INetworkLog} contract — the
+ * exact pattern the interface javadoc documents for consumers.
+ */
+@Data
+@Accessors(chain = true)
+public class TestNetworkLog implements INetworkLog {
+    private String requestId;
+    private Instant requestTimestamp;
+    private String method;
+    private String fullUrl;
+    private String path;
+    private Map<String, Object> requestHeaders;
+    private Map<String, Object> queryParams;
+    private Map<String, Object> pathParams;
+    private JsonNode requestBody;
+    private Map<String, Object> additionalData;
+    private Boolean endpointCalled;
+    private Integer responseStatus;
+    private Map<String, Object> responseHeaders;
+    private JsonNode responseBody;
+    private Map<String, Object> errorDetail;
+}

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/testapp/NetworkLogStorageTestApp.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/testapp/NetworkLogStorageTestApp.java
@@ -1,0 +1,30 @@
+package com.davidrandoll.spring_web_captor.storage.testapp;
+
+import com.davidrandoll.spring_web_captor.storage.NetworkLogEnricher;
+import com.davidrandoll.spring_web_captor.storage.support.InMemoryNetworkLogStore;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Minimal application that activates the storage auto-configuration end-to-end: it supplies a concrete
+ * {@link com.davidrandoll.spring_web_captor.storage.INetworkLogStore} (so the listener bean is created) and a
+ * {@link NetworkLogEnricher}, then lets a real HTTP request flow captor -> events -> storage listener -> store.
+ */
+@SpringBootApplication
+public class NetworkLogStorageTestApp {
+
+    @Bean
+    public InMemoryNetworkLogStore inMemoryNetworkLogStore() {
+        return new InMemoryNetworkLogStore();
+    }
+
+    @Bean
+    public NetworkLogEnricher tenantEnricher() {
+        return (log, event) -> {
+            if (log.getAdditionalData() == null) {
+                log.setAdditionalData(new java.util.HashMap<>());
+            }
+            log.getAdditionalData().put("enrichedTenant", "acme");
+        };
+    }
+}

--- a/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/testapp/StorageTestController.java
+++ b/spring-web-captor-storage/src/test/java/com/davidrandoll/spring_web_captor/storage/testapp/StorageTestController.java
@@ -1,0 +1,16 @@
+package com.davidrandoll.spring_web_captor.storage.testapp;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class StorageTestController {
+
+    @GetMapping("/api/widgets/{id}")
+    public ResponseEntity<String> widget(@PathVariable String id, @RequestParam(required = false) String color) {
+        return ResponseEntity.ok("widget-" + id + "-" + color);
+    }
+}

--- a/spring-web-captor-xml/pom.xml
+++ b/spring-web-captor-xml/pom.xml
@@ -20,26 +20,28 @@
     </properties>
 
     <dependencies>
+        <!-- compile+optional (not provided): kept non-transitive for consumers but present on this
+             module's native-image test classpath (provided is excluded from the native runtime classpath). -->
         <dependency>
             <groupId>com.davidrandoll</groupId>
             <artifactId>spring-web-captor</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-web-captor-xml/src/main/java/com/davidrandoll/spring_web_captor/WebCaptorXmlConfig.java
+++ b/spring-web-captor-xml/src/main/java/com/davidrandoll/spring_web_captor/WebCaptorXmlConfig.java
@@ -11,7 +11,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 
 @Slf4j
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @Conditional(IsWebCaptorEnabled.class)
 @RequiredArgsConstructor
 public class WebCaptorXmlConfig {

--- a/spring-web-captor-xml/src/test/java/com/davidrandoll/spring_web_captor/nativesupport/WebCaptorXmlNativeTest.java
+++ b/spring-web-captor-xml/src/test/java/com/davidrandoll/spring_web_captor/nativesupport/WebCaptorXmlNativeTest.java
@@ -1,0 +1,60 @@
+package com.davidrandoll.spring_web_captor.nativesupport;
+
+import com.davidrandoll.spring_web_captor.WebCaptorXmlApplication;
+import com.davidrandoll.spring_web_captor.event.HttpRequestEvent;
+import com.davidrandoll.spring_web_captor.setup.EventCaptureListener;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * GraalVM-native-capable boot test for the XML extension. Boots the XML body parsers ENABLED and pushes a real
+ * {@code application/xml} body through the captor, asserting the XML-to-JsonNode parsing and the subsequent
+ * Jackson serialization of the captured event both survive under a closed-world native image. No Mockito.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = WebCaptorXmlApplication.class)
+@AutoConfigureMockMvc
+@Tag("native")
+class WebCaptorXmlNativeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EventCaptureListener eventCaptureListener;
+
+    @BeforeEach
+    void setUp() {
+        eventCaptureListener.clearEvents();
+    }
+
+    @Test
+    void parsesXmlBodyAndSerializesEventUnderNative() throws Exception {
+        String xml = "<user><name>David</name></user>";
+        mockMvc.perform(post("/test/body/xml")
+                        .contentType(MediaType.APPLICATION_XML)
+                        .content(xml))
+                .andExpect(status().isOk());
+
+        HttpRequestEvent request = eventCaptureListener.getRequestEvents().getFirst();
+        assertThat(request.getRequestBody().get("name").asText()).isEqualTo("David");
+
+        String json = objectMapper.writeValueAsString(request);
+        assertThat(json).contains("David");
+        com.fasterxml.jackson.databind.JsonNode tree = objectMapper.readTree(json);
+        assertThat(tree.findValue("name").asText()).isEqualTo("David");
+    }
+}

--- a/spring-web-captor/pom.xml
+++ b/spring-web-captor/pom.xml
@@ -21,15 +21,19 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
+        <!-- compile+optional (not provided): a library API consumers must still supply themselves
+             (optional => non-transitive), but on the classpath of this module's own native-image test
+             build. provided-scope deps are excluded from the native-image runtime classpath, which makes
+             the JUnitPlatformFeature fail reflecting test fields typed against these libs (e.g. ObjectMapper). -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-web-captor/src/main/java/com/davidrandoll/spring_web_captor/aot/WebCaptorRuntimeHints.java
+++ b/spring-web-captor/src/main/java/com/davidrandoll/spring_web_captor/aot/WebCaptorRuntimeHints.java
@@ -1,0 +1,60 @@
+package com.davidrandoll.spring_web_captor.aot;
+
+import com.davidrandoll.spring_web_captor.event.BaseHttpEvent;
+import com.davidrandoll.spring_web_captor.event.BodyPayload;
+import com.davidrandoll.spring_web_captor.event.HttpMethodEnum;
+import com.davidrandoll.spring_web_captor.event.HttpRequestEvent;
+import com.davidrandoll.spring_web_captor.event.HttpResponseEvent;
+import com.davidrandoll.spring_web_captor.event.SerializedFile;
+import com.davidrandoll.spring_web_captor.properties.WebCaptorProperties;
+import org.springframework.aot.hint.BindingReflectionHintsRegistrar;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+import org.springframework.util.LinkedMultiValueMap;
+
+/**
+ * Registers GraalVM native-image reflection metadata for the captor's event/DTO graph so that consuming
+ * services can serialize/deserialize captured events (e.g. into a workflow context, an audit row, or a
+ * message body) under a closed-world native image WITHOUT each consumer re-registering the library's own
+ * types.
+ *
+ * <p>Contributed unconditionally via {@code META-INF/spring/aot.factories} (rather than
+ * {@code @ImportRuntimeHints} on the auto-configuration) so the hints are present even when the consumer
+ * wires the captor beans manually or the auto-config is filtered out during AOT processing.</p>
+ *
+ * <p>{@link BindingReflectionHintsRegistrar} walks the property graph of each seed type transitively, so the
+ * nested {@code MultiValueMap}/{@code Map}/{@code JsonNode} fields are covered. The concrete container
+ * implementations that appear behind interface-typed fields ({@link LinkedMultiValueMap} behind
+ * {@code MultiValueMap}, {@link HttpHeaders}) are registered explicitly because the graph walk only sees the
+ * declared interface type.</p>
+ */
+public class WebCaptorRuntimeHints implements RuntimeHintsRegistrar {
+
+    private final BindingReflectionHintsRegistrar bindingRegistrar = new BindingReflectionHintsRegistrar();
+
+    @Override
+    public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+        bindingRegistrar.registerReflectionHints(hints.reflection(),
+                // Event graph serialized by consumers (workflow context, audit, messaging, ...).
+                BaseHttpEvent.class,
+                HttpRequestEvent.class,
+                HttpResponseEvent.class,
+                BodyPayload.class,
+                SerializedFile.class,
+                HttpMethodEnum.class,
+                // Concrete container types hidden behind interface-typed fields.
+                LinkedMultiValueMap.class,
+                HttpHeaders.class,
+                HttpStatus.class,
+                // @ConfigurationProperties binding target + nested groups (belt-and-suspenders; Spring Boot's
+                // AOT config-properties processing normally covers these, but registering here guarantees
+                // binding even if the consumer activates the captor outside standard auto-configuration).
+                WebCaptorProperties.class,
+                WebCaptorProperties.EventDetails.class,
+                WebCaptorProperties.AdditionalDetails.class,
+                WebCaptorProperties.ExcludedRequest.class);
+    }
+}

--- a/spring-web-captor/src/main/java/com/davidrandoll/spring_web_captor/config/AppConfig.java
+++ b/spring-web-captor/src/main/java/com/davidrandoll/spring_web_captor/config/AppConfig.java
@@ -40,7 +40,9 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
 import java.util.EnumSet;
 import java.util.List;
 
-@Configuration
+// proxyBeanMethods=false: no @Bean method calls another, so CGLIB enhancement is unnecessary — and
+// runtime CGLIB enhancement is unsupported under a GraalVM native image.
+@Configuration(proxyBeanMethods = false)
 public class AppConfig {
     @Bean
     @ConditionalOnMissingBean

--- a/spring-web-captor/src/main/java/com/davidrandoll/spring_web_captor/config/WebConfig.java
+++ b/spring-web-captor/src/main/java/com/davidrandoll/spring_web_captor/config/WebConfig.java
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@Configuration("webCaptorWebConfig")
+@Configuration(value = "webCaptorWebConfig", proxyBeanMethods = false)
 @EnableWebMvc
 @RequiredArgsConstructor
 @Conditional(IsWebCaptorEnabled.class)

--- a/spring-web-captor/src/main/java/com/davidrandoll/spring_web_captor/field_captor/captors/RequestQueryParamsCaptor.java
+++ b/spring-web-captor/src/main/java/com/davidrandoll/spring_web_captor/field_captor/captors/RequestQueryParamsCaptor.java
@@ -2,16 +2,25 @@ package com.davidrandoll.spring_web_captor.field_captor.captors;
 
 import com.davidrandoll.spring_web_captor.event.HttpRequestEvent;
 import com.davidrandoll.spring_web_captor.field_captor.IRequestFieldCaptor;
+import com.davidrandoll.spring_web_captor.publisher.request.CachedBodyHttpServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class RequestQueryParamsCaptor implements IRequestFieldCaptor {
+
+    private static final String FORM_CONTENT_TYPE = "application/x-www-form-urlencoded";
+
     @Override
     public void capture(HttpServletRequest request, HttpRequestEvent.HttpRequestEventBuilder<?, ?> builder) {
         var params = this.getRequestParams(request);
@@ -19,13 +28,114 @@ public class RequestQueryParamsCaptor implements IRequestFieldCaptor {
     }
 
     public MultiValueMap<String, String> getRequestParams(HttpServletRequest request) {
+        var fromParameterMap = this.fromParameterMap(request);
+        // GraalVM native image: the servlet container's getParameterMap() can come back EMPTY for a request
+        // that plainly has a query string (observed on the workflow-engine getParticipantProfile path —
+        // ?entityId=... captured as {}). The single library-relevant native build hint that would force
+        // Tomcat's lazy query parser to populate (-H:+AddAllCharsets) is already present in the consuming
+        // service, yet the map is still empty under native — so Tomcat's lazy parameter parser cannot be
+        // relied on under native and the raw fallback below is the PRIMARY mechanism there, not a guard.
+        //
+        // The fallback reconstructs what getParameterMap() returns on the JVM: it merges the URI query
+        // string AND (for x-www-form-urlencoded POSTs) the form body, preserves multi-value keys, and
+        // URL-decodes using the request's character encoding. It depends only on String ops + a byte->String
+        // decode, so it is native-safe. On the JVM the parameter map is populated, so the fallback is a no-op.
+        if (!fromParameterMap.isEmpty()) {
+            return fromParameterMap;
+        }
+        return this.fromRawRequest(request);
+    }
+
+    private MultiValueMap<String, String> fromParameterMap(HttpServletRequest request) {
         return request.getParameterMap()
                 .entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
-                        entry -> entry.getValue() != null ? Arrays.asList(entry.getValue()) : Collections.emptyList(),
+                        entry -> entry.getValue() != null ? Arrays.asList(entry.getValue()) : Collections.<String>emptyList(),
                         (a, b) -> b,
                         LinkedMultiValueMap::new
                 ));
+    }
+
+    /**
+     * Native-safe reconstruction of the request parameters when {@link HttpServletRequest#getParameterMap()}
+     * yields nothing. Mirrors the servlet contract for {@code getParameterMap()}: query-string parameters are
+     * merged with {@code application/x-www-form-urlencoded} body parameters (POST only), keeping every value of
+     * a repeated key.
+     */
+    private MultiValueMap<String, String> fromRawRequest(HttpServletRequest request) {
+        Charset charset = resolveCharset(request);
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        // Query-string params (from the URI — independent of the request body).
+        parseUrlEncoded(request.getQueryString(), charset, params);
+
+        // Form-encoded POST body params — getParameterMap() merges these on the JVM, so mirror it.
+        if (isFormPost(request)) {
+            parseUrlEncoded(readFormBody(request, charset), charset, params);
+        }
+
+        return params;
+    }
+
+    private static boolean isFormPost(HttpServletRequest request) {
+        String contentType = request.getContentType();
+        return contentType != null
+                && contentType.toLowerCase().contains(FORM_CONTENT_TYPE)
+                && "POST".equalsIgnoreCase(request.getMethod());
+    }
+
+    /**
+     * Reads the cached request body (never the live stream) so the body can still be read again by the
+     * downstream body captor. Only the {@link CachedBodyHttpServletRequest} wrapper guarantees a re-readable
+     * body; for any other request type the form body is skipped rather than risking stream consumption.
+     */
+    private String readFormBody(HttpServletRequest request, Charset charset) {
+        try {
+            if (request instanceof CachedBodyHttpServletRequest cached) {
+                byte[] body = cached.getCachedBody();
+                if (body != null && body.length > 0) {
+                    return new String(body, charset);
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Could not read cached form body for query-param fallback: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static Charset resolveCharset(HttpServletRequest request) {
+        try {
+            String encoding = request.getCharacterEncoding();
+            if (encoding != null && !encoding.isBlank()) {
+                return Charset.forName(encoding);
+            }
+        } catch (Exception e) {
+            // Unsupported/illegal charset name — fall through to UTF-8.
+        }
+        return StandardCharsets.UTF_8;
+    }
+
+    /**
+     * Parse {@code key=value&key2=value2} text into the supplied multi-value map, URL-decoding keys and values
+     * with the given charset and preserving repeated keys.
+     */
+    private void parseUrlEncoded(String raw, Charset charset, MultiValueMap<String, String> params) {
+        if (raw == null || raw.isBlank()) {
+            return;
+        }
+        for (String pair : raw.split("&")) {
+            if (pair.isEmpty()) {
+                continue;
+            }
+            int eq = pair.indexOf('=');
+            String rawKey = eq >= 0 ? pair.substring(0, eq) : pair;
+            String rawValue = eq >= 0 ? pair.substring(eq + 1) : "";
+            String key = URLDecoder.decode(rawKey, charset);
+            String value = URLDecoder.decode(rawValue, charset);
+            if (!key.isEmpty()) {
+                params.add(key, value);
+            }
+        }
     }
 }

--- a/spring-web-captor/src/main/java/com/davidrandoll/spring_web_captor/properties/WebCaptorProperties.java
+++ b/spring-web-captor/src/main/java/com/davidrandoll/spring_web_captor/properties/WebCaptorProperties.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 
 @Data
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConfigurationProperties(prefix = "web-captor")
 public class WebCaptorProperties {
     private boolean enabled = true;

--- a/spring-web-captor/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-web-captor/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=\
+com.davidrandoll.spring_web_captor.aot.WebCaptorRuntimeHints

--- a/spring-web-captor/src/test/java/com/davidrandoll/spring_web_captor/aot/WebCaptorRuntimeHintsTest.java
+++ b/spring-web-captor/src/test/java/com/davidrandoll/spring_web_captor/aot/WebCaptorRuntimeHintsTest.java
@@ -1,0 +1,59 @@
+package com.davidrandoll.spring_web_captor.aot;
+
+import com.davidrandoll.spring_web_captor.event.BaseHttpEvent;
+import com.davidrandoll.spring_web_captor.event.BodyPayload;
+import com.davidrandoll.spring_web_captor.event.HttpMethodEnum;
+import com.davidrandoll.spring_web_captor.event.HttpRequestEvent;
+import com.davidrandoll.spring_web_captor.event.HttpResponseEvent;
+import com.davidrandoll.spring_web_captor.event.SerializedFile;
+import com.davidrandoll.spring_web_captor.properties.WebCaptorProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.LinkedMultiValueMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Asserts the library self-registers its event/DTO graph for native-image binding so that consuming services
+ * do not have to re-register the captor's own types.
+ */
+class WebCaptorRuntimeHintsTest {
+
+    private final RuntimeHints hints = new RuntimeHints();
+
+    WebCaptorRuntimeHintsTest() {
+        new WebCaptorRuntimeHints().registerHints(hints, getClass().getClassLoader());
+    }
+
+    @Test
+    @DisplayName("registers reflection/binding hints for every captured event + DTO type")
+    void registersEventGraph() {
+        assertThat(RuntimeHintsPredicates.reflection().onType(BaseHttpEvent.class)).accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(HttpRequestEvent.class)).accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(HttpResponseEvent.class)).accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(BodyPayload.class)).accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(SerializedFile.class)).accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(HttpMethodEnum.class)).accepts(hints);
+    }
+
+    @Test
+    @DisplayName("registers the concrete container types behind interface-typed fields")
+    void registersContainerTypes() {
+        assertThat(RuntimeHintsPredicates.reflection().onType(LinkedMultiValueMap.class)).accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(HttpHeaders.class)).accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(HttpStatus.class)).accepts(hints);
+    }
+
+    @Test
+    @DisplayName("registers @ConfigurationProperties binding targets")
+    void registersConfigurationProperties() {
+        assertThat(RuntimeHintsPredicates.reflection().onType(WebCaptorProperties.class)).accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(WebCaptorProperties.EventDetails.class)).accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(WebCaptorProperties.AdditionalDetails.class)).accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(WebCaptorProperties.ExcludedRequest.class)).accepts(hints);
+    }
+}

--- a/spring-web-captor/src/test/java/com/davidrandoll/spring_web_captor/nativesupport/WebCaptorNativeTest.java
+++ b/spring-web-captor/src/test/java/com/davidrandoll/spring_web_captor/nativesupport/WebCaptorNativeTest.java
@@ -1,0 +1,83 @@
+package com.davidrandoll.spring_web_captor.nativesupport;
+
+import com.davidrandoll.spring_web_captor.WebCaptorApplication;
+import com.davidrandoll.spring_web_captor.event.HttpRequestEvent;
+import com.davidrandoll.spring_web_captor.event.HttpResponseEvent;
+import com.davidrandoll.spring_web_captor.setup.EventCaptureListener;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * GraalVM-native-capable boot test for the core captor. Boots the captor ENABLED, drives a real request
+ * through the filter chain, and round-trips the captured events through Jackson. The event/DTO graph is what
+ * consuming services serialize (into a workflow context, an audit row, a message body); under a closed-world
+ * native image that serialization fails unless {@code WebCaptorRuntimeHints} registered the binding metadata,
+ * so this test is exactly the gap-catcher. No Mockito — real MockMvc + real objects only.
+ *
+ * <p>The query-param assertions also cover the {@code RequestQueryParamsCaptor} path whose native-only
+ * empty-{@code getParameterMap()} fallback was the original bug.</p>
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = WebCaptorApplication.class)
+@AutoConfigureMockMvc
+@Tag("native")
+class WebCaptorNativeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventCaptureListener eventCaptureListener;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        eventCaptureListener.clearEvents();
+    }
+
+    @Test
+    void capturesAndSerializesRequestEventUnderNative() throws Exception {
+        mockMvc.perform(get("/test/query/basic?color=blue&size=large"))
+                .andExpect(status().isOk());
+
+        HttpRequestEvent req = eventCaptureListener.getRequestEvents().getFirst();
+        assertThat(req.getQueryParams().get("color")).containsExactly("blue");
+        assertThat(req.getQueryParams().get("size")).containsExactly("large");
+
+        // Serialization is what breaks under native without the registered binding hints. (Consumers
+        // serialize the event and bind it into a tree/map/audit row; the interface-typed queryParams field
+        // is not deserialized straight back into the event type, so we assert against the parsed tree.)
+        String json = objectMapper.writeValueAsString(req);
+        assertThat(json).contains("color").contains("blue");
+
+        com.fasterxml.jackson.databind.JsonNode tree = objectMapper.readTree(json);
+        assertThat(tree.get("queryParams").get("color").get(0).asText()).isEqualTo("blue");
+        assertThat(tree.get("path").asText()).isEqualTo(req.getPath());
+    }
+
+    @Test
+    void capturesAndSerializesResponseEventUnderNative() throws Exception {
+        mockMvc.perform(get("/test/query/basic?color=red"))
+                .andExpect(status().isOk());
+
+        HttpResponseEvent res = eventCaptureListener.getResponseEvents().getFirst();
+        assertThat(res.getResponseStatus().value()).isEqualTo(200);
+
+        String json = objectMapper.writeValueAsString(res);
+        assertThat(json).isNotBlank();
+        com.fasterxml.jackson.databind.JsonNode tree = objectMapper.readTree(json);
+        assertThat(tree).isNotNull();
+        assertThat(tree.has("path")).isTrue();
+    }
+}

--- a/spring-web-captor/src/test/java/com/davidrandoll/spring_web_captor/query_params/RequestQueryParamsCaptorTest.java
+++ b/spring-web-captor/src/test/java/com/davidrandoll/spring_web_captor/query_params/RequestQueryParamsCaptorTest.java
@@ -1,0 +1,120 @@
+package com.davidrandoll.spring_web_captor.query_params;
+
+import com.davidrandoll.spring_web_captor.field_captor.captors.RequestQueryParamsCaptor;
+import com.davidrandoll.spring_web_captor.publisher.request.CachedBodyHttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.util.MultiValueMap;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link RequestQueryParamsCaptor}.
+ *
+ * <p>The native-only bug: under GraalVM native image, {@code HttpServletRequest.getParameterMap()} came back
+ * EMPTY for a request that plainly had a query string (the workflow-engine {@code getParticipantProfile}
+ * path captured {@code ?entityId=...} as {@code {}}), so the participant id resolved to "" and the request
+ * 500'd. This is reproduced on the JVM by a {@link MockHttpServletRequest} that has a query string but no
+ * registered parameters — exactly the shape the native container produced.</p>
+ */
+class RequestQueryParamsCaptorTest {
+
+    private static final String UUID = "0002189f-60d2-4431-9b02-d02b93fc569e";
+
+    private final RequestQueryParamsCaptor captor = new RequestQueryParamsCaptor();
+
+    @Test
+    @DisplayName("captures params from getParameterMap (normal JVM path)")
+    void capturesFromParameterMap() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/license/workflow-engine/getParticipantProfile");
+        request.setParameter("entityId", UUID);
+        request.setParameter("entityType", "individual");
+
+        MultiValueMap<String, String> params = captor.getRequestParams(request);
+
+        assertThat(params.getFirst("entityId")).isEqualTo(UUID);
+        assertThat(params.getFirst("entityType")).isEqualTo("individual");
+    }
+
+    @Test
+    @DisplayName("REGRESSION: falls back to the raw query string when getParameterMap is empty (native condition)")
+    void capturesFromQueryStringWhenParameterMapEmpty() {
+        // Simulate the native container: query string present, but getParameterMap() returns {}.
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/license/workflow-engine/getParticipantProfile");
+        request.setQueryString("entityId=" + UUID + "&entityType=individual&include=profile");
+        // deliberately NO setParameter(...) -> getParameterMap() is empty
+
+        assertThat(request.getParameterMap()).isEmpty(); // guards the precondition this test relies on
+
+        MultiValueMap<String, String> params = captor.getRequestParams(request);
+
+        // Without the query-string fallback this map is empty and these assertions fail.
+        assertThat(params.getFirst("entityId")).isEqualTo(UUID);
+        assertThat(params.getFirst("entityType")).isEqualTo("individual");
+        assertThat(params.getFirst("include")).isEqualTo("profile");
+    }
+
+    @Test
+    @DisplayName("query-string fallback URL-decodes keys and values")
+    void fallbackUrlDecodes() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/x");
+        request.setQueryString("q=hello%20world&tag=a%26b");
+
+        MultiValueMap<String, String> params = captor.getRequestParams(request);
+
+        assertThat(params.getFirst("q")).isEqualTo("hello world");
+        assertThat(params.getFirst("tag")).isEqualTo("a&b");
+    }
+
+    @Test
+    @DisplayName("query-string fallback preserves repeated (multi-value) keys")
+    void fallbackKeepsMultiValueKeys() {
+        // FAIL-WITHOUT-FIX: the pre-fix fallback used Map semantics and would drop all but one value of `id`.
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/x");
+        request.setQueryString("id=1&id=2&id=3&type=dog");
+
+        MultiValueMap<String, String> params = captor.getRequestParams(request);
+
+        assertThat(params.get("id")).containsExactly("1", "2", "3");
+        assertThat(params.getFirst("type")).isEqualTo("dog");
+    }
+
+    @Test
+    @DisplayName("REGRESSION: falls back to the form-encoded POST body when getParameterMap is empty (native condition)")
+    void fallbackParsesFormUrlEncodedBody() {
+        // Simulate the native container for a form POST: form body present, but getParameterMap() returns {}.
+        // FAIL-WITHOUT-FIX: the pre-fix fallback only read getQueryString() and returned {} here, losing the body params.
+        MockHttpServletRequest delegate = new MockHttpServletRequest("POST", "/api/form");
+        delegate.setContentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+        delegate.setContent(("entityId=" + UUID + "&role=admin&role=editor").getBytes(StandardCharsets.UTF_8));
+        // deliberately NO setParameter(...) -> getParameterMap() is empty
+
+        CachedBodyHttpServletRequest request = new CachedBodyHttpServletRequest(delegate);
+        assertThat(request.getParameterMap()).isEmpty(); // guards the precondition this test relies on
+
+        MultiValueMap<String, String> params = captor.getRequestParams(request);
+
+        assertThat(params.getFirst("entityId")).isEqualTo(UUID);
+        assertThat(params.get("role")).containsExactly("admin", "editor");
+    }
+
+    @Test
+    @DisplayName("form-body fallback merges query-string and body params (mirrors getParameterMap on the JVM)")
+    void fallbackMergesQueryAndBody() {
+        MockHttpServletRequest delegate = new MockHttpServletRequest("POST", "/api/form");
+        delegate.setQueryString("source=web");
+        delegate.setContentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+        delegate.setContent("name=fido".getBytes(StandardCharsets.UTF_8));
+
+        CachedBodyHttpServletRequest request = new CachedBodyHttpServletRequest(delegate);
+
+        MultiValueMap<String, String> params = captor.getRequestParams(request);
+
+        assertThat(params.getFirst("source")).isEqualTo("web");
+        assertThat(params.getFirst("name")).isEqualTo("fido");
+    }
+}


### PR DESCRIPTION
Register runtime hints and native-friendly changes so the library works under GraalVM native images. Added WebCaptorRuntimeHints and NetworkLogStorageRuntimeHints plus META-INF/spring/aot.factories entries. Implemented a native-safe fallback in RequestQueryParamsCaptor to reconstruct parameters when getParameterMap() is empty (parses query string and form bodies, preserves multi-values and decoding). Converted several @Configuration classes to proxyBeanMethods=false, switched module provided scopes to optional for native test classpaths, and added many unit/integration/native-capable tests. Also added jacoco/native-maven plugin configs, a Windows native-test.bat, and lombok.config.